### PR TITLE
Do not discard unnamed OSM objects.

### DIFF
--- a/example-configs/carto-de.lua
+++ b/example-configs/carto-de.lua
@@ -31,9 +31,8 @@ function process(objtype, object)
               object.tags[l10n_tag] = name
           end
       end
-      return object.tags
     end
-    return false
+    return object.tags
 end
 
 function ott.process_node(object)


### PR DESCRIPTION
Forgot to remove the discarding of unnamed objects which I have been using for testing and which is not an option for production use.